### PR TITLE
Bugfix for pyaudio install and removed IP section

### DIFF
--- a/stretch_install_user.sh
+++ b/stretch_install_user.sh
@@ -121,7 +121,7 @@ echo "Install pip Python profiler output viewer (SnakeViz)"
 python -m pip install --user snakeviz
 
 echo "Install pip Python packages for Respeaker and speech recognition"
-python -m pip install --user pyusb pyaudio SpeechRecognition pixel-ring click
+python -m pip install --user pyusb SpeechRecognition pixel-ring click
 cd ~/repos/usb_4_mic_array/
 echo " - Flashing Respeaker with 6 channel firmware"
 sudo python2 dfu.py --download 6_channels_firmware.bin

--- a/stretch_install_user.sh
+++ b/stretch_install_user.sh
@@ -298,12 +298,6 @@ echo "DONE WITH ADDITIONAL ADDITIONAL PIP PACKAGES"
 echo "###########################################"
 echo ""
 
-echo "The IP address for this machine follows:"
-curl ifconfig.me
-echo ""
-echo "Make it a static IP and then use it for SSH and VNC."
-echo "Done!"
-
 echo "DONE WITH STRETCH_USER_INSTALL"
 echo "###########################################"
 echo ""


### PR DESCRIPTION
No need to explicitly install pyaudio via pip (which errors on building) since `apt install ros-melodic-respeaker-ros` installs `python-pyaudio` as well.

I removed the IP section shown at the end of `stretch_user_install.sh` because it shows the public IP address of the robot, which isn't useful for ssh-ing. Even showing the network IP address isn't useful since the robot's IP address is likely to be changed by the network unless made static in the router's settings.