### PR TITLE
Fix for software being installed after selected no in y/n prompt

### DIFF
--- a/factory/stretch_install_factory.sh
+++ b/factory/stretch_install_factory.sh
@@ -5,6 +5,10 @@ echo "Starting installation for a new robot."
 echo "#############################################"
 cd $HOME/stretch_install/factory
 ./stretch_setup_new_robot.sh
+if [ $? -ne 0 ]
+then
+	exit 1
+fi
 echo "#############################################"
 echo "Done with initial setup. Starting software install."
 echo "#############################################"


### PR DESCRIPTION
The y/n prompt in `stretch_install_factory.sh` and `stretch_install_nonfactory.sh` was not being respected, as reported in #16. The error code is now checked before continuing with software install.