### PR TITLE
fixes startup timing issue for xbox controller

### DIFF
--- a/factory/hello_robot_xbox_teleop.sh
+++ b/factory/hello_robot_xbox_teleop.sh
@@ -4,5 +4,10 @@
 export HELLO_FLEET_ID HELLO_FLEET_ID
 export PYTHONPATH=/opt/ros/melodic/lib/python2.7/dist-packages
 export HELLO_FLEET_PATH=$HOME/stretch_user
-/usr/bin/python $HOME/.local/bin/stretch_xbox_controller_teleop.py
+
+/usr/bin/python $HOME/.local/bin/xbox_dongle_init.py > $HOME/stretch_user/log/xbox_out.log
+
+sleep 1
+
+/usr/bin/python $HOME/.local/bin/stretch_xbox_controller_teleop.py >> $HOME/stretch_user/log/xbox_out.log
 

--- a/factory/stretch_setup_new_robot.sh
+++ b/factory/stretch_setup_new_robot.sh
@@ -36,6 +36,7 @@ rm -rf stretch_fleet
 #Allow shutdown without password
 
 #Startup scripts
+sudo cp $DIR/xbox_dongle_init.py ~/.local/bin
 sudo cp $DIR/hello_robot_audio.sh /usr/bin
 sudo cp $DIR/hello_robot_lrf_off.py /usr/bin
 sudo cp $DIR/hello_robot_xbox_teleop.sh /usr/bin

--- a/factory/xbox_dongle_init.py
+++ b/factory/xbox_dongle_init.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from inputs import get_gamepad
+
+def main():
+    try:
+        events = get_gamepad()
+    except Exception as e:
+        print("Exception thrown--------------")
+        print(e)
+    else:
+        print("dongle connected--------------")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The latest xbox teleop script requires this fix in order to startup automatically on boot (due to hardware changes of the game controller).

