### PR TITLE
Pimu pinging & Misc. Fixes

### DIFF
--- a/factory/hello_robot_pimu_ping.desktop
+++ b/factory/hello_robot_pimu_ping.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=hello_robot_pimu_ping
+Exec= /usr/bin/hello_robot_pimu_ping.sh
+Hidden=false
+X-GNOME-Autostart-enabled=true

--- a/factory/hello_robot_pimu_ping.py
+++ b/factory/hello_robot_pimu_ping.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import stretch_body.pimu
+import time
+#This script establishes communications with the Pimu at launch then shutsdown
+#This has the effect of letting the Pimu know that Ubuntu Desktop is live (which drives its LightBar state machine)
+
+print('Starting up Pimu Ping on %s'%time.asctime())
+ping_success=False
+for i in range(10):
+	p = stretch_body.pimu.Pimu()
+	if p.startup():
+		print('Successful ping of Pimu on try %d'%i)
+		p.stop()
+		exit(0)
+	p.stop()
+	time.sleep(1.0)
+
+print('Failed to ping Pimu')
+
+
+

--- a/factory/hello_robot_pimu_ping.sh
+++ b/factory/hello_robot_pimu_ping.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+. /etc/hello-robot/hello-robot.conf
+export HELLO_FLEET_ID HELLO_FLEET_ID
+export PYTHONPATH=/opt/ros/melodic/lib/python2.7/dist-packages
+export HELLO_FLEET_PATH=$HOME/stretch_user
+
+/usr/bin/python /usr/bin/hello_robot_pimu_ping.py >> $HOME/stretch_user/log/hello_robot_pimu_ping.log
+

--- a/factory/stretch_dex_wrist_yaml_configure.py
+++ b/factory/stretch_dex_wrist_yaml_configure.py
@@ -3,6 +3,8 @@
 from __future__ import print_function
 import stretch_body.hello_utils
 import argparse
+from os.path import exists
+import sys
 
 parser=argparse.ArgumentParser(description='Update YAML for a Dex Wrist install')
 parser.add_argument("--factory", help="Is a factory install",action="store_true")
@@ -29,6 +31,10 @@ else:
         'hello-motor-lift':{'gains':{'i_safety_feedforward':0.75}}
     }
 
+if not exists(hello_utils.get_fleet_directory()+'stretch_user_params.yaml'):
+    print('Please run tool RE1_migrate_params.py before continuing. For more details, see https://forum.hello-robot.com/t/425')
+    sys.exit(1)
 user_yaml=stretch_body.hello_utils.read_fleet_yaml('stretch_user_params.yaml')
 stretch_body.hello_utils.overwrite_dict(overwritee_dict=user_yaml, overwriter_dict=dex_wrist_yaml)
-stretch_body.hello_utils.write_fleet_yaml('stretch_user_params.yaml',user_yaml)
+stretch_body.hello_utils.write_fleet_yaml('stretch_user_params.yaml', user_yaml,
+                                          header=stretch_body.robot_params.RobotParams().get_user_params_header())

--- a/factory/stretch_setup_new_robot.sh
+++ b/factory/stretch_setup_new_robot.sh
@@ -40,6 +40,8 @@ mkdir -p ~/.local/bin
 sudo cp $DIR/xbox_dongle_init.py ~/.local/bin/
 sudo cp $DIR/hello_robot_audio.sh /usr/bin/
 sudo cp $DIR/hello_robot_lrf_off.py /usr/bin/
+sudo cp $DIR/hello_robot_pimu_ping.py /usr/bin/
+sudo cp $DIR/hello_robot_pimu_ping.sh /usr/bin/
 sudo cp $DIR/hello_robot_xbox_teleop.sh /usr/bin/
 sudo cp $DIR/hello_sudoers /etc/sudoers.d/
 

--- a/stretch_install_user.sh
+++ b/stretch_install_user.sh
@@ -72,6 +72,7 @@ mkdir -p ~/.config/autostart
 cp ~/repos/stretch_install/factory/hello_robot_audio.desktop ~/.config/autostart/
 cp ~/repos/stretch_install/factory/hello_robot_xbox_teleop.desktop ~/.config/autostart/
 cp ~/repos/stretch_install/factory/hello_robot_lrf_off.desktop ~/.config/autostart/
+cp ~/repos/stretch_install/factory/hello_robot_pimu_ping.desktop ~/.config/autostart/
 echo "Done."
 echo ""
 


### PR DESCRIPTION
This PR adds Pimu pinging to the installation, which is used by the light bar in the Mitski variant of the robot. Additionally, the Dex Wrist configure tool now checks for that Stretch Body v0.3's migration tool was run before saving params to the new YAML files.