### PR TITLE
rosdep update specific distros

### DIFF
--- a/factory/20.04/stretch_install_system.sh
+++ b/factory/20.04/stretch_install_system.sh
@@ -79,7 +79,8 @@ if [ -f "/etc/ros/rosdep/sources.list.d/20-default.list" ]; then
     sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
 fi
 sudo rosdep init >> $REDIRECT_LOGFILE
-rosdep update >> $REDIRECT_LOGFILE
+rosdep update --rosdistro=noetic >> $REDIRECT_LOGFILE
+rosdep update --rosdistro=galactic >> $REDIRECT_LOGFILE
 echo "Install vcstool"
 install python3-vcstool
 echo ""


### PR DESCRIPTION
This update fixes rosdep update error due to Galactic EOL. Instead of doing a simple rosdep update which only pulls the sources for active distros (no longer includes Galactic), this update adds the flag --rosdistro=DISTRO_NAME to the rosdep update command to pull only the package databases for Noetic and Galactic.