### PR TITLE
Update dex wrist install script for ROS 2

### DIFF
--- a/stretch_new_dex_wrist_install.sh
+++ b/stretch_new_dex_wrist_install.sh
@@ -24,22 +24,33 @@ REx_dynamixel_set_baud.py /dev/hello-dynamixel-wrist 13 115200
 echo "Configuring user YAML"
 ./factory/$factory_osdir/stretch_dex_wrist_yaml_configure.py $1
 
-echo "Setting up Stretch ROS and URDF"
-cd ~/catkin_ws/src/stretch_ros/
-git pull
+echo "Updating ROS or ROS 2 workspace to work with a dex wrist"
+echo "Pleas source the ROS distribution you want to work with before proceeding"
+if [ $ROS_VERSION = 1 ]
+then
+    echo "Setting up Stretch ROS and URDF"
+    cd ~/catkin_ws/src/stretch_ros/
+    git pull
 
-cd ~/repos
-git clone https://github.com/hello-robot/stretch_tool_share
-cd ~/repos/stretch_tool_share
-git pull
-cd ~/repos/stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description
-cp urdf/stretch_dex_wrist.xacro ~/catkin_ws/src/stretch_ros/stretch_description/urdf
-cp urdf/stretch_description.xacro ~/catkin_ws/src/stretch_ros/stretch_description/urdf
-cp meshes/*.STL ~/catkin_ws/src/stretch_ros/stretch_description/meshes
+    cd ~/repos
+    git clone https://github.com/hello-robot/stretch_tool_share
+    cd ~/repos/stretch_tool_share
+    git pull
+    cd ~/repos/stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description
+    cp urdf/stretch_dex_wrist.xacro ~/catkin_ws/src/stretch_ros/stretch_description/urdf
+    cp urdf/stretch_description.xacro ~/catkin_ws/src/stretch_ros/stretch_description/urdf
+    cp meshes/*.STL ~/catkin_ws/src/stretch_ros/stretch_description/meshes
 
+    echo "Updating URDF calibration "
+    rosrun stretch_calibration update_urdf_after_xacro_change.sh
+    cd ~/catkin_ws/src/stretch_ros/stretch_description/urdf
+    ./export_urdf.sh
+else
+    echo "Updating Stretch ROS 2 and URDF"
+    cd ~/ament_ws/src/stretch_ros2
+    git pull
 
-echo "Updating URDF calibration "
-rosrun stretch_calibration update_urdf_after_xacro_change.sh
-cd ~/catkin_ws/src/stretch_ros/stretch_description/urdf
-./export_urdf.sh
-
+    ros2 run hello_helpers configure_wrist --dex
+    cd ~/ament_ws/src/stretch_ros2/stretch_description/urdf
+    ./export_urdf.sh
+fi


### PR DESCRIPTION
Updates the stretch_new_dex_wrist_install.sh script to work with both ROS and ROS 2 depending on which distro is sourced.