### PR TITLE
Add scripts for dex to standard wrist switch

### DIFF
--- a/factory/20.04/stretch_standard_wrist_yaml_configure.py
+++ b/factory/20.04/stretch_standard_wrist_yaml_configure.py
@@ -1,0 +1,34 @@
+#! /usr/bin/env python3
+
+from __future__ import print_function
+import stretch_body.hello_utils
+import stretch_body.robot_params
+import argparse
+from os.path import exists
+import sys
+
+model_name=stretch_body.robot_params.RobotParams()._robot_params['robot']['model_name']
+
+if model_name=='RE2V0':
+    dex_wrist_yaml = {
+    'robot': {'use_collision_manager': 1, 'tool': 'tool_stretch_gripper'},
+    'params': [],
+    'stretch_gripper': {'range_t': [0, 8022], 'zero_t': 5212}, 
+    'lift': {'i_feedforward': 1.2},
+    'hello-motor-lift': {'gains': {'i_safety_feedforward': 1.2}}}
+if model_name == 'RE1V0':
+    dex_wrist_yaml = {
+    'robot': {'use_collision_manager': 1, 'tool': 'tool_stretch_gripper'},
+    'params': [],
+    'stretch_gripper': {'range_t': [0, 8022], 'zero_t': 5212}, 
+    'lift': {'i_feedforward': 0.54},
+    'hello-motor-lift': {'gains': {'i_safety_feedforward': 0.4}}}
+
+if not exists(stretch_body.hello_utils.get_fleet_directory()+'stretch_configuration_params.yaml'):
+    print('Please run tool RE1_migrate_params.py before continuing. For more details, see https://forum.hello-robot.com/t/425')
+    sys.exit(1)
+
+configuration_yaml=stretch_body.hello_utils.read_fleet_yaml('stretch_configuration_params.yaml')
+stretch_body.hello_utils.overwrite_dict(overwritee_dict=configuration_yaml, overwriter_dict=dex_wrist_yaml)
+stretch_body.hello_utils.write_fleet_yaml('stretch_configuration_params.yaml', configuration_yaml,
+                                          header=stretch_body.robot_params.RobotParams().get_configuration_params_header())

--- a/stretch_dex_to_standard_wrist.sh
+++ b/stretch_dex_to_standard_wrist.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+cd ~/stretch_install
+python3 ./factory/20.04/stretch_standard_wrist_yaml_configure.py
+
+echo "Updating ROS or ROS 2 workspace to work with a standard wrist"
+echo "---------------------------------------------------------------------------"
+echo "Please source the ROS distribution you want to work with before proceeding"
+echo "---------------------------------------------------------------------------"
+if [ $ROS_VERSION = 1 ]
+then
+    echo "Setting up Stretch ROS and URDF"
+    cd ~/catkin_ws/src/stretch_ros/
+    git pull
+
+    cd ~/catkin_ws/src/stretch_ros/stretch_description/urdf
+    cp stretch_description_standard.xacro stretch_description.xacro
+
+    echo "Updating URDF calibration"
+    rosrun stretch_calibration update_urdf_after_xacro_change.sh
+    cd ~/catkin_ws/src/stretch_ros/stretch_description/urdf
+    ./export_urdf.sh
+else
+    echo "Updating Stretch ROS 2 and URDF"
+    cd ~/ament_ws/src/stretch_ros2
+    git pull
+    
+    cd ~/ament_ws
+    colcon build
+    source install/setup.bash
+
+    ros2 run hello_helpers configure_wrist --standard
+    colcon build
+    cd ~/ament_ws/src/stretch_ros2/stretch_description/urdf
+    ./export_urdf.sh
+fi

--- a/stretch_new_dex_wrist_install.sh
+++ b/stretch_new_dex_wrist_install.sh
@@ -34,14 +34,8 @@ then
     cd ~/catkin_ws/src/stretch_ros/
     git pull
 
-    cd ~/repos
-    git clone https://github.com/hello-robot/stretch_tool_share
-    cd ~/repos/stretch_tool_share
-    git pull
-    cd ~/repos/stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description
-    cp urdf/stretch_dex_wrist.xacro ~/catkin_ws/src/stretch_ros/stretch_description/urdf
-    cp urdf/stretch_description.xacro ~/catkin_ws/src/stretch_ros/stretch_description/urdf
-    cp meshes/*.STL ~/catkin_ws/src/stretch_ros/stretch_description/meshes
+    cd ~/catkin_ws/src/stretch_ros/stretch_description/urdf
+    cp stretch_description_dex.xacro stretch_description.xacro
 
     echo "Updating URDF calibration "
     rosrun stretch_calibration update_urdf_after_xacro_change.sh

--- a/stretch_new_dex_wrist_install.sh
+++ b/stretch_new_dex_wrist_install.sh
@@ -26,7 +26,7 @@ echo "Configuring user YAML"
 
 echo "Updating ROS or ROS 2 workspace to work with a dex wrist"
 echo "---------------------------------------------------------------------------"
-echo "Pleas source the ROS distribution you want to work with before proceeding"
+echo "Please source the ROS distribution you want to work with before proceeding"
 echo "---------------------------------------------------------------------------"
 if [ $ROS_VERSION = 1 ]
 then
@@ -57,6 +57,7 @@ else
     source install/setup.bash
 
     ros2 run hello_helpers configure_wrist --dex
+    colcon build
     cd ~/ament_ws/src/stretch_ros2/stretch_description/urdf
     ./export_urdf.sh
 fi


### PR DESCRIPTION
Changes in this PR reduce the process of switching from a dex to a standard wrist to a single step.

Simply execute the following in stretch_install root directory:
./stretch_dex_to_standard_wrist.sh

For the above command to execute successfully in ROS 1, the stretch_description/urdf directory needs to house stretch_description_{wrist_type}.xacro files for both dex and standard wrist, just like in stretch_ros2.