### PR TITLE
Fix firmware update step for 22.04 install

### DIFF
--- a/factory/22.04/stretch_install_firmware.sh
+++ b/factory/22.04/stretch_install_firmware.sh
@@ -13,7 +13,7 @@ echo "###########################################"
 
 #To install Arduino CLI
 echo "Installing arduino-cli"
-curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/.local/bin/ sh
+curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/.local/bin/ sh 0.31.0
 $HOME/.local/bin/arduino-cli config init
 $HOME/.local/bin/arduino-cli core install arduino:samd@1.6.21
 sed -i -e 's#Arduino#repos/stretch_firmware/arduino#g' ~/.arduino15/arduino-cli.yaml

--- a/factory/22.04/stretch_install_firmware.sh
+++ b/factory/22.04/stretch_install_firmware.sh
@@ -10,6 +10,14 @@ REDIRECT_LOGFILE="$REDIRECT_LOGDIR/stretch_install_firmware.`date '+%Y%m%d%H%M'`
 echo "###########################################"
 echo "INSTALLATION OF STRETCH FIRMWARE"
 echo "###########################################"
+
+#To install Arduino CLI
+echo "Installing arduino-cli"
+curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/.local/bin/ sh
+$HOME/.local/bin/arduino-cli config init
+$HOME/.local/bin/arduino-cli core install arduino:samd@1.6.21
+sed -i -e 's#Arduino#repos/stretch_firmware/arduino#g' ~/.arduino15/arduino-cli.yaml
+
 source ~/.bashrc
 echo "Read ttyACMx mapping"
 REx_firmware_flash.py --map &>> $REDIRECT_LOGFILE


### PR DESCRIPTION
@hello-binit I wanted to try out the iron install scripts and it failed because of a missing arduino-cli install. 

The firmware install step in this PR is preceded by the install steps for arduino-cli. Not sure if this is the place where you intend it to be. Let me know if you need it elsewhere.