### PR TITLE
Switch to ROS2 Humble again

### DIFF
--- a/docs/robot_install.md
+++ b/docs/robot_install.md
@@ -14,7 +14,7 @@ Currently, there are 3 available versions of the software stack, listed from old
 
  1. **(Deprecated)** Ubuntu 18.04 LTS shipped on robots until summer 2022, and included software for ROS Melodic and Python2
  2. **(Stable)** Ubuntu 20.04 LTS comes with ROS Noetic and Python3.8. This is what currently ships on robots.
- 3. **(Experimental)** Ubuntu 22.04 LTS comes with ROS2 Iron and Python3.10. In the future, this version will ship on robots. **Warning:** Both the installation scripts and the software installed are under active development. Please proceed with caution.
+ 3. **(Experimental)** Ubuntu 22.04 LTS comes with ROS2 Humble and Python3.10. In the future, this version will ship on robots. **Warning:** Both the installation scripts and the software installed are under active development. Please proceed with caution.
 
 # How
 

--- a/docs/ros_workspace.md
+++ b/docs/ros_workspace.md
@@ -17,7 +17,7 @@ git pull
 
 ### Ubuntu 18.04
 
-Run the following command to create a ROS1 workspace (replacing `<optional-path-to-ws>` for the `-w` flag with a filepath to the workspace. Not providing the flag defaults to `~/catkin_ws`).
+Run the following command to create a ROS1 Melodic workspace (replacing `<optional-path-to-ws>` for the `-w` flag with a filepath to the workspace. Not providing the flag defaults to `~/catkin_ws`).
 
 ```bash
 ./factory/18.04/stretch_create_catkin_workspace.sh -w <optional-path-to-ws>
@@ -25,14 +25,18 @@ Run the following command to create a ROS1 workspace (replacing `<optional-path-
 
 ### Ubuntu 20.04
 
-Choose one of the following commands to create either or both ROS1/ROS2 workspaces (replacing `<optional-path-to-ws>` for the `-w` flag with a filepath to the workspace. Not providing the flag defaults to `~/catkin_ws` or `~/ament_ws`).
+Run the following command to create a ROS1 Noetic workspace (replacing `<optional-path-to-ws>` for the `-w` flag with a filepath to the workspace. Not providing the flag defaults to `~/catkin_ws`).
 
 ```bash
-# Create a ROS1 workspace
 ./factory/20.04/stretch_create_catkin_workspace.sh -w <optional-path-to-ws>
+```
 
-# Create a ROS2 workspace
-./factory/20.04/stretch_create_ament_workspace.sh -w <optional-path-to-ws>
+### Ubuntu 22.04
+
+Run the following command to create a ROS2 Humble workspace (replacing `<optional-path-to-ws>` for the `-w` flag with a filepath to the workspace. Not providing the flag defaults to `~/ament_ws`).
+
+```bash
+./factory/22.04/stretch_create_ament_workspace.sh -w <optional-path-to-ws>
 ```
 
 ### Wrap up

--- a/factory/20.04/stretch_initial_setup.sh
+++ b/factory/20.04/stretch_initial_setup.sh
@@ -135,3 +135,8 @@ sudo cp $DIR/hello_robot_xbox_teleop.sh /usr/bin/
 echo "Setting up apt retries..."
 echo 'Acquire::Retries "3";' > 80-retries
 sudo mv 80-retries /etc/apt/apt.conf.d/
+
+echo "Prevent screen dimming..."
+gsettings set org.gnome.desktop.session idle-delay 0 &> /dev/null || true
+gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-timeout 0 &> /dev/null || true
+gsettings set org.gnome.settings-daemon.plugins.power idle-dim false &> /dev/null || true

--- a/factory/22.04/iron2humble_migration.md
+++ b/factory/22.04/iron2humble_migration.md
@@ -1,0 +1,44 @@
+# Iron -> Humble Migration
+
+The Stretch Install repo has switched the version of ROS2 installed with the Ubuntu 22.04 software stack. On Sept 7th, 2023, we switched it to ROS2 Iron. On Sept 14, 2023, we switched it back to ROS2 Humble. We expect some users to have upgraded in that week, so this guide serves to help migrate from Iron -> Humble.
+
+## Steps
+
+ 0. Verify this guide applies to you
+    ```
+    lsb_release -d
+    echo $ROS_DISTRO
+    ```
+    You should see "Description: Ubuntu 22.04.* LTS" and "iron". If not, you do not need this guide.
+
+ 1. Clone Stretch Install into your home folder:
+    ```
+    cd ~/
+    git clone https://github.com/hello-robot/stretch_install.git
+    cd ~/stretch_install
+    git pull
+    ```
+
+ 2. Run the system install script
+    ```
+    ./factory/22.04/stretch_install_system.sh
+    ```
+    The script can fails silently. If the last line printed out isn't "Install librealsense2 packages", something went wrong. Contact Hello Robot Support.
+
+ 3. Update the .bashrc script
+    ```
+    gedit ~/.bashrc
+    ```
+    A text editor will open. Scroll to the bottom of the file, and look for a section called "STRETCH BASHRC SETUP". Under this section, you'll see a line that says `source /opt/ros/iron/setup.bash`. Change this line to `source /opt/ros/humble/setup.bash`. Next, look for a line that says `source $HOME/ament_ws/install/setup.bash` or similar. Delete this line. Now save the file and close the editor.
+
+ 4. Refresh your terminal by closing your current terminal and opening a new one
+
+ 5. Run the ament workspace creation script
+    ```
+    ./factory/20.04/stretch_create_ament_workspace.sh
+    ```
+    The script can fails silently. If the last line printed out isn't "Setup calibrated robot URDF...", something went wrong. Contact Hello Robot Support.
+
+ 6. Refresh your terminal by closing your current terminal and opening a new one
+
+Success! Your robot is now set up with ROS2 Humble correctly.

--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -18,15 +18,15 @@ done
 REDIRECT_LOGFILE="$REDIRECT_LOGDIR/stretch_create_ament_workspace.`date '+%Y%m%d%H%M'`_redirected.txt"
 
 echo "###########################################"
-echo "CREATING IRON AMENT WORKSPACE at $AMENT_WSDIR"
+echo "CREATING HUMBLE AMENT WORKSPACE at $AMENT_WSDIR"
 echo "###########################################"
 
 echo "Ensuring correct version of ROS is sourced..."
-if [[ $ROS_DISTRO && ! $ROS_DISTRO = "iron" ]]; then
+if [[ $ROS_DISTRO && ! $ROS_DISTRO = "humble" ]]; then
     echo "Cannot create workspace while a conflicting ROS version is sourced. Exiting."
     exit 1
 fi
-source /opt/ros/iron/setup.bash
+source /opt/ros/humble/setup.bash
 
 if [[ -d $AMENT_WSDIR ]]; then
     echo "You are about to delete and replace the existing ament workspace. If you have any personal data in the workspace, please create a back up before proceeding."
@@ -54,7 +54,7 @@ cd $AMENT_WSDIR/src
 vcs import --input ~/stretch_install/factory/22.04/stretch_ros2_iron.repos >> $REDIRECT_LOGFILE
 echo "Fetch ROS packages' dependencies (this might take a while)..."
 cd $AMENT_WSDIR/
-rosdep install --rosdistro=iron -iyr --skip-keys="librealsense2" --from-paths src &>> $REDIRECT_LOGFILE
+rosdep install --rosdistro=humble -iyr --skip-keys="librealsense2" --from-paths src &>> $REDIRECT_LOGFILE
 echo "Compile the workspace (this might take a while)..."
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release &>> $REDIRECT_LOGFILE
 echo "Source setup.bash file..."

--- a/factory/22.04/stretch_initial_setup.sh
+++ b/factory/22.04/stretch_initial_setup.sh
@@ -137,6 +137,6 @@ echo 'Acquire::Retries "3";' > 80-retries
 sudo mv 80-retries /etc/apt/apt.conf.d/
 
 echo "Prevent screen dimming..."
-gsettings set org.gnome.desktop.session idle-delay 0
-gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-timeout 0
-gsettings set org.gnome.settings-daemon.plugins.power idle-dim false
+gsettings set org.gnome.desktop.session idle-delay 0 &> /dev/null || true
+gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-timeout 0 &> /dev/null || true
+gsettings set org.gnome.settings-daemon.plugins.power idle-dim false &> /dev/null || true

--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -65,9 +65,9 @@ echo "Install APT HTTPS"
 install apt-transport-https
 echo ""
 
-# https://docs.ros.org/en/iron/Installation/Ubuntu-Install-Debians.html
+# https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
 echo "###########################################"
-echo "INSTALLATION OF ROS 2 IRON"
+echo "INSTALLATION OF ROS 2 HUMBLE"
 echo "###########################################"
 echo "Setting up keys"
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
@@ -75,8 +75,8 @@ echo "Setting up sources.list"
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 echo "Apt update"
 sudo apt-get --yes update >> $REDIRECT_LOGFILE
-echo "Install ROS 2 Iron (this might take a while)"
-install ros-iron-desktop-full
+echo "Install ROS 2 Humble (this might take a while)"
+install ros-humble-desktop-full
 # https://discourse.ros.org/t/ros-developer-tools-now-in-binary-form/29802
 echo "Install ROS 2 Dev Tools"
 install ros-dev-tools
@@ -95,19 +95,19 @@ install python3-vcstool
 echo ""
 
 echo "###########################################"
-echo "INSTALLATION OF ADDITIONAL ROS IRON PKGS"
+echo "INSTALLATION OF ADDITIONAL ROS HUMBLE PKGS"
 echo "###########################################"
 echo "Install packages to work with URDFs"
 install liburdfdom-tools meshlab
-install ros-iron-urdfdom-py
+install ros-humble-urdfdom-py
 echo "Install joint state GUI package"
-install ros-iron-joint-state-publisher-gui
+install ros-humble-joint-state-publisher-gui
 echo "Install IMU visualization plugin for RViz and IMU filter"
-install ros-iron-rviz-imu-plugin ros-iron-imu-filter-madgwick
+install ros-humble-rviz-imu-plugin ros-humble-imu-filter-madgwick
 echo "Install robot localization package for use with IMU and wheel odometry"
-install ros-iron-robot-localization
+install ros-humble-robot-localization
 echo "Install teleop packages"
-install ros-iron-teleop-twist-keyboard
+install ros-humble-teleop-twist-keyboard
 echo ""
 
 echo "###########################################"

--- a/factory/22.04/stretch_ros2_iron.repos
+++ b/factory/22.04/stretch_ros2_iron.repos
@@ -2,7 +2,7 @@ repositories:
   ros2_numpy:
     type: git
     url: https://github.com/hello-binit/ros2_numpy
-    version: iron
+    version: humble
   realsense-ros:
     type: git
     url: https://github.com/IntelRealSense/realsense-ros.git
@@ -10,7 +10,7 @@ repositories:
   stretch_ros2:
     type: git
     url: https://github.com/hello-robot/stretch_ros2.git
-    version: iron
+    version: humble
   sllidar_ros2:
     type: git
     url: https://github.com/Slamtec/sllidar_ros2.git
@@ -18,13 +18,13 @@ repositories:
   stretch_tutorials:
     type: git
     url: https://github.com/hello-robot/stretch_tutorials.git
-    version: iron
+    version: humble
   respeaker_ros2:
     type: git
-    url: https://github.com/hello-chintan/respeaker_ros2.git
-    version: iron
+    url: https://github.com/hello-binit/respeaker_ros2.git
+    version: humble
   audio_common:
     type: git
-    url: https://github.com/hello-chintan/audio_common.git
-    version: iron
+    url: https://github.com/hello-binit/audio_common.git
+    version: humble
  

--- a/stretch_new_user_install.sh
+++ b/stretch_new_user_install.sh
@@ -39,7 +39,7 @@ else
     elif [[ $factory_osdir = "20.04" ]]; then
         echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc
     elif [[ $factory_osdir = "22.04" ]]; then
-        echo "source /opt/ros/iron/setup.bash" >> ~/.bashrc
+        echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
     fi
 fi
 

--- a/stretch_new_user_install.sh
+++ b/stretch_new_user_install.sh
@@ -55,7 +55,7 @@ mkdir -p ~/stretch_user/models
 echo "Cloning Stretch deep perception models..."
 cd ~/stretch_user
 if [ ! -d "$HOME/stretch_user/stretch_deep_perception_models" ]; then
-    git clone https://github.com/hello-robot/stretch_deep_perception_models >> $REDIRECT_LOGFILE
+    git clone https://github.com/hello-robot/stretch_deep_perception_models &>> $REDIRECT_LOGFILE
 fi
 cd stretch_deep_perception_models
 git pull >> $REDIRECT_LOGFILE


### PR DESCRIPTION
This PR switches the Ubuntu 22.04 software stack to using the ROS2 Humble distribution again.