### PR TITLE
Fix typo in catkin ws creation scripts

### DIFF
--- a/factory/18.04/stretch_create_catkin_workspace.sh
+++ b/factory/18.04/stretch_create_catkin_workspace.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -u
 
 REDIRECT_LOGDIR="$HOME/stretch_user/log"
 CATKIN_WSDIR="$HOME/catkin_ws"
@@ -28,7 +29,7 @@ if [[ $ROS_DISTRO && ! $ROS_DISTRO = "melodic" ]]; then
 fi
 source /opt/ros/melodic/setup.bash
 
-if [[ -d $AMENT_WSDIR ]]; then
+if [[ -d $CATKIN_WSDIR ]]; then
     echo "You are about to delete and replace the existing catkin workspace. If you have any personal data in the workspace, please create a back up before proceeding."
     prompt_yes_no(){
     read -p "Do you want to continue? Press (y/n for yes/no): " x

--- a/factory/20.04/stretch_create_catkin_workspace.sh
+++ b/factory/20.04/stretch_create_catkin_workspace.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -u
 
 REDIRECT_LOGDIR="$HOME/stretch_user/log"
 CATKIN_WSDIR="$HOME/catkin_ws"
@@ -28,7 +29,7 @@ if [[ $ROS_DISTRO && ! $ROS_DISTRO = "noetic" ]]; then
 fi
 source /opt/ros/noetic/setup.bash
 
-if [[ -d $AMENT_WSDIR ]]; then
+if [[ -d $CATKIN_WSDIR ]]; then
     echo "You are about to delete and replace the existing catkin workspace. If you have any personal data in the workspace, please create a back up before proceeding."
     prompt_yes_no(){
     read -p "Do you want to continue? Press (y/n for yes/no): " x

--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -u
 
 REDIRECT_LOGDIR="$HOME/stretch_user/log"
 AMENT_WSDIR="$HOME/ament_ws"


### PR DESCRIPTION
This PR fixes a typo in the `stretch_create_catkin_workspace.sh` to check the existence of `$CATKIN_WSDIR` instead of `$AMENT_WSDIR` on Ubuntu 18.04 and 20.04. The bash `nounset` option is also turned on to catch unset variables.