### PR TITLE
Fix #55 - Disables dpkg prompt to override motd config

### DIFF
--- a/factory/22.04/motd/10dpkg_options
+++ b/factory/22.04/motd/10dpkg_options
@@ -1,0 +1,4 @@
+Dpkg::Options {
+   "--force-confdef";
+   "--force-confold";
+}

--- a/factory/22.04/stretch_initial_setup.sh
+++ b/factory/22.04/stretch_initial_setup.sh
@@ -152,6 +152,7 @@ if [ -d /etc/update-motd.d/ ]; then
     sudo chmod +x /etc/update-motd.d/00-header
     sudo cp $DIR/motd/10-help-text /etc/update-motd.d/10-help-text
     sudo chmod +x /etc/update-motd.d/10-help-text
+    sudo cp $DIR/motd/10dpkg_options /etc/apt/apt.conf.d/10dpkg_options
 fi
 if [ -f /etc/update-motd.d/50-motd-news ]; then
     sudo chmod -x /etc/update-motd.d/50-motd-news


### PR DESCRIPTION
Solves #55 