### PR TITLE
Fix sunshine systemd wrong unit launching

### DIFF
--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -175,3 +175,7 @@ function add_sunshine_uinput_rule {
 add_sunshine_uinput_rule &>> $REDIRECT_LOGFILE
 echo "Setup Sunshine apps"
 sudo cp ./sunshine_apps.json /usr/share/sunshine/apps.json
+echo "Setup Sunshine systemd unit"
+mkdir -p ~/.config/systemd/user/
+cp ./sunshine.service ~/.config/systemd/user/sunshine.service
+

--- a/factory/22.04/sunshine.service
+++ b/factory/22.04/sunshine.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sunshine self-hosted game stream host for Moonlight.
+StartLimitIntervalSec=500
+StartLimitBurst=5
+
+[Service]
+ExecStart=/usr/bin/sunshine
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
When launching Sunshine via systemd, it uses a version located at /usr/lib/systemd/user/sunshine.service, which in turn launches all of the Startup Applications (even the disabled ones) and the "Welcome to Ubuntu" wizard. This is verified by running: systemctl --user list-dependencies xdg-desktop-autostart.target With this commit, we save a version of sunshine.service to ~/.config/systemd/user/sunshine.service and this is the version used by launching Sunshine via systemd. The startup apps and wizard are now not appearing.