### PR TITLE
Blacklist Nintendo HID kernel module in 22.04

### DIFF
--- a/factory/22.04/stretch_initial_setup.sh
+++ b/factory/22.04/stretch_initial_setup.sh
@@ -169,3 +169,8 @@ fi
 
 echo "Switching from Wayland to X11..."
 sudo sed -i -e 's/#WaylandEnable=false/WaylandEnable=false/g' /etc/gdm3/custom.conf
+
+echo 'Blacklisting hid_nintendo that conflicts with Xpad driver...'
+echo  '# Nintendo conflicts with Xpad controller driver' | sudo tee -a /etc/modprobe.d/blacklist.conf
+echo  'blacklist hid_nintendo' | sudo tee -a /etc/modprobe.d/blacklist.conf
+sudo update-initramfs -u


### PR DESCRIPTION
This PR prevents the Nintendo HID kernel from loading on Ubunut 22.04 which conflicts with the Xpad kernel module that is used by the gamepad controller.