### PR TITLE
Pin realsense-ros to 4.55.1

### DIFF
--- a/factory/22.04/stretch_ros2_humble.repos
+++ b/factory/22.04/stretch_ros2_humble.repos
@@ -6,7 +6,7 @@ repositories:
   realsense-ros:
     type: git
     url: https://github.com/IntelRealSense/realsense-ros.git
-    version: ros2-development
+    version: 4.55.1
   stretch_ros2:
     type: git
     url: https://github.com/hello-robot/stretch_ros2.git


### PR DESCRIPTION
Pins realsense-ros to a know version for which support exists within Stretch ROS2. This pin should be updated when the Realsense team releases new versions and we've verified they work with the launch files / code inside Stretch ROS2.