### PR TITLE
Switch `_colcon_cd_root`

### DIFF
--- a/stretch_new_user_install.sh
+++ b/stretch_new_user_install.sh
@@ -40,12 +40,12 @@ else
     echo "export PATH=\${PATH}:~/.local/bin" >> ~/.bashrc
     echo "export LRS_LOG_LEVEL=None #Debug" >> ~/.bashrc
     echo "export PYTHONWARNINGS='ignore:setup.py install is deprecated,ignore:Invalid dash-separated options,ignore:pkg_resources is deprecated as an API,ignore:Usage of dash-separated'" >> ~/.bashrc
-    echo "export _colcon_cd_root=${HOME}" >> ~/.bashrc
     if [[ $factory_osdir = "18.04" ]]; then
         echo "source /opt/ros/melodic/setup.bash" >> ~/.bashrc
     elif [[ $factory_osdir = "20.04" ]]; then
         echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc
     elif [[ $factory_osdir = "22.04" ]]; then
+        echo "export _colcon_cd_root=${HOME}/ament_ws" >> ~/.bashrc
         echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
     fi
 fi


### PR DESCRIPTION
# Description

This PR makes two changes:

1. Sets the colcon cd root to the workspace's top-level directory, so colcon_cd works.
2. Only sets the colcon cd root for Ubuntu 22.04, because only ROS2 uses colcon as a build system (ROS1 uses catkin)

# Testing

- [x] Recreate the issue: on a Stretch, ensure `_colcon_cd_root` in the `.bashrc` is the home directory, source the bashrc, and run `colcon_cd stretch_web_teleop`. Verify it fails.
- [x] Verify the fix: on a Stretch, change `_colcon_cd_root` in the `.bashrc` to point to `ament_ws` within the home directory, source the bashrc, and run `colcon_cd stretch_web_teleop`. Verify it succeeds.