### PR TITLE
Replace certificate creation scripts with standalone script

### DIFF
--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -73,20 +73,8 @@ npx playwright install &>> $REDIRECT_LOGFILE
 echo "Creating web interface specialized URDF..."
 python3 prepare_specialized_urdf.py &>> $REDIRECT_LOGFILE
 echo "Generating web interface certs..."
-cd $AMENT_WSDIR/src/stretch_web_teleop/certificates
-curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" &>> $REDIRECT_LOGFILE
-chmod +x mkcert-v*-linux-amd64
-sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
-CAROOT=`pwd` mkcert --install &>> $REDIRECT_LOGFILE
-mkdir -p ~/.local/share/mkcert
-rm -rf ~/.local/share/mkcert/root*
-cp root* ~/.local/share/mkcert
-mkcert ${HELLO_FLEET_ID} ${HELLO_FLEET_ID}.local ${HELLO_FLEET_ID}.dev localhost 127.0.0.1 0.0.0.0 ::1 &>> $REDIRECT_LOGFILE
-rm mkcert-v*-linux-amd64
 cd $AMENT_WSDIR/src/stretch_web_teleop
-touch .env
-echo certfile=${HELLO_FLEET_ID}+6.pem >> .env
-echo keyfile=${HELLO_FLEET_ID}+6-key.pem >> .env
+./create_certificates.sh
 cd $AMENT_WSDIR/
 echo "Compile the workspace (this might take a while)..."
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release &>> $REDIRECT_LOGFILE


### PR DESCRIPTION
This PR removes the certification creation commands for the web teleop from the create ament_ws script and instead calls the `create_cerficates.sh` script that should exist in the Stretch web teleop package directory. This PR needs to be coupled with this PR https://github.com/hello-robot/stretch_web_teleop/pull/69 before merging.