### PR TITLE
Removed web app's specialized URDF script

### DIFF
--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -70,8 +70,6 @@ cd $AMENT_WSDIR/src/stretch_web_teleop
 pip3 install -r requirements.txt &>> $REDIRECT_LOGFILE
 npm install --force &>> $REDIRECT_LOGFILE
 npx playwright install &>> $REDIRECT_LOGFILE
-echo "Creating web interface specialized URDF..."
-python3 prepare_specialized_urdf.py &>> $REDIRECT_LOGFILE
 echo "Generating web interface certs..."
 cd $AMENT_WSDIR/src/stretch_web_teleop/certificates
 curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" &>> $REDIRECT_LOGFILE


### PR DESCRIPTION
Joint with [`stretch_production_tools`#24](https://github.com/hello-robot/stretch_production_tools/pull/24) and [`stretch_web_teleop`#83](https://github.com/hello-robot/stretch_web_teleop/pull/83).

Although [`stretch_install`#72](https://github.com/hello-robot/stretch_install/pull/72/files) changed `stretch_create_ament_workspace.sh` to run `prepare_specialized_urdf.py`, that won't actually work since the URDFs don't get generated until after that script is run. As discussed with @hello-fazil and @hello-vinitha , this PR (and its joint PRs, above):

1. Stops running `prepare_specialized_urdf.py` as part of creating the ROS2 workspace.
2. Instead, adds instructions to run that script as part of the Python SDK QC process.
3. Raises an exception in the web teleop launchfile if the URDFs don't exist, with instructions on how to create them.