### PR TITLE
Wifi connect

### DIFF
--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -184,11 +184,16 @@ echo "Ensure NetworkManager enabled & dhcpcd disabled"
 echo "NetworkManager is $(systemctl -p LoadState --value show "NetworkManager") and $(systemctl -p ActiveState --value show "NetworkManager")" &>> $REDIRECT_LOGFILE
 echo "dhcpcd is $(systemctl -p LoadState --value show "dhcpcd") and $(systemctl -p ActiveState --value show "dhcpcd")" &>> $REDIRECT_LOGFILE
 echo "Download and extract WiFi Connect"
-_regex='browser_download_url": "\K.*x86_64.*(?=")'
-RELEASE_URL="https://api.github.com/repos/balena-os/wifi-connect/releases/170779858"
-_arch_url=$(curl "$RELEASE_URL" -s | grep -hoP "$_regex")
+_regex1='browser_download_url": "\K.*x86_64.*(?=")'
+RELEASE_URL1="https://api.github.com/repos/balena-os/wifi-connect/releases/170779858"
+_arch_url=$(curl "$RELEASE_URL1" -s | grep -hoP "$_regex1")
 mkdir -p /tmp/wfc
 curl -Ls "$_arch_url" | tar -xz -C "/tmp/wfc"
 sudo mv /tmp/wfc/wifi-connect /usr/local/sbin
-sudo mkdir -p /usr/local/share/wifi-connect/ui
+sudo mkdir -p /usr/local/share/wifi-connect
+_regex2='browser_download_url": "\K.*rpi\.tar\.gz'
+RELEASE_URL2="https://api.github.com/repos/balena-os/wifi-connect/releases/45509064"
+_ui_url=$(curl "$RELEASE_URL2" -s | grep -hoP "$_regex2")
+curl -Ls "$_ui_url" | tar -xz -C "/tmp/wfc"
+sudo mv /tmp/wfc/ui /usr/local/share/wifi-connect/
 sudo rm -rf /tmp/wfc

--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -191,9 +191,6 @@ mkdir -p /tmp/wfc
 curl -Ls "$_arch_url" | tar -xz -C "/tmp/wfc"
 sudo mv /tmp/wfc/wifi-connect /usr/local/sbin
 sudo mkdir -p /usr/local/share/wifi-connect
-_regex2='browser_download_url": "\K.*rpi\.tar\.gz'
-RELEASE_URL2="https://api.github.com/repos/balena-os/wifi-connect/releases/45509064"
-_ui_url=$(curl "$RELEASE_URL2" -s | grep -hoP "$_regex2")
-curl -Ls "$_ui_url" | tar -xz -C "/tmp/wfc"
+git clone https://github.com/hello-binit/wifi-connect-ui /tmp/wfc/ui
 sudo mv /tmp/wfc/ui /usr/local/share/wifi-connect/
 sudo rm -rf /tmp/wfc

--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -175,4 +175,20 @@ sudo cp ./sunshine_apps.json /usr/share/sunshine/apps.json
 echo "Setup Sunshine systemd unit"
 mkdir -p ~/.config/systemd/user/
 cp ./sunshine.service ~/.config/systemd/user/sunshine.service
+echo ""
 
+echo "###########################################"
+echo "INSTALLATION OF WiFi Connect"
+echo "###########################################"
+echo "Ensure NetworkManager enabled & dhcpcd disabled"
+echo "NetworkManager is $(systemctl -p LoadState --value show "NetworkManager") and $(systemctl -p ActiveState --value show "NetworkManager")" &>> $REDIRECT_LOGFILE
+echo "dhcpcd is $(systemctl -p LoadState --value show "dhcpcd") and $(systemctl -p ActiveState --value show "dhcpcd")" &>> $REDIRECT_LOGFILE
+echo "Download and extract WiFi Connect"
+_regex='browser_download_url": "\K.*x86_64.*(?=")'
+RELEASE_URL="https://api.github.com/repos/balena-os/wifi-connect/releases/170779858"
+_arch_url=$(curl "$RELEASE_URL" -s | grep -hoP "$_regex")
+mkdir -p /tmp/wfc
+curl -Ls "$_arch_url" | tar -xz -C "/tmp/wfc"
+sudo mv /tmp/wfc/wifi-connect /usr/local/sbin
+sudo mkdir -p /usr/local/share/wifi-connect/ui
+sudo rm -rf /tmp/wfc


### PR DESCRIPTION
This PR uses `wifi-connect` to enable a user to set up Wifi credentials for the Stretch without needing to plug in a monitor or SSH into the robot. `wifi-connect` achieves this by starting a hotspot with the robot's hostname. When you connect to this hotspot with your phone or laptop, a captive portal appears. These captive portals are typically used by coffee shops/airports to log you into the network, but in this case, it provides a form in which the user can provide the SSID/password credentials for their home network. After the user presses enter, `wifi-connect` disables its hotspot, attempts to connect to the home network, and either succeeds, or fails and retries by bringing up the hotspot again.