### PR TITLE
Enable web teleop to start on boot

### DIFF
--- a/factory/22.04/hello_sudoers
+++ b/factory/22.04/hello_sudoers
@@ -1,5 +1,3 @@
-Cmnd_Alias USER_SERVICES = /usr/bin/systemctl start [servicename], /usr/bin/systemctl stop [servicename], /usr/bin/systemctl restart [servicename]
+Cmnd_Alias ONBOOT_WEBTELEOP_SERVICES = /sbin/shutdown, /usr/bin/udevadm, /usr/bin/pkill
 
-[username] ALL=(ALL) NOPASSWD:USER_SERVICES
-
-ALL ALL=(ALL) NOPASSWD: /sbin/shutdown
+ALL ALL=(ALL) NOPASSWD:ONBOOT_WEBTELEOP_SERVICES

--- a/factory/22.04/hello_sudoers
+++ b/factory/22.04/hello_sudoers
@@ -1,3 +1,3 @@
-Cmnd_Alias ONBOOT_WEBTELEOP_SERVICES = /sbin/shutdown, /usr/bin/udevadm, /usr/bin/pkill
+Cmnd_Alias ONBOOT_WEBTELEOP_SERVICES = /sbin/shutdown, /usr/bin/udevadm, /usr/bin/pkill, /usr/local/sbin/wifi-connect
 
 ALL ALL=(ALL) NOPASSWD:ONBOOT_WEBTELEOP_SERVICES

--- a/factory/22.04/hello_sudoers
+++ b/factory/22.04/hello_sudoers
@@ -1,1 +1,5 @@
+Cmnd_Alias USER_SERVICES = /usr/bin/systemctl start [servicename], /usr/bin/systemctl stop [servicename], /usr/bin/systemctl restart [servicename]
+
+[username] ALL=(ALL) NOPASSWD:USER_SERVICES
+
 ALL ALL=(ALL) NOPASSWD: /sbin/shutdown

--- a/factory/22.04/stretch_initial_setup.sh
+++ b/factory/22.04/stretch_initial_setup.sh
@@ -126,7 +126,7 @@ echo "Setting up UDEV rules..."
 sudo cp /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules /etc/udev/rules.d
 sudo udevadm control --reload
 
-echo "Allow shutdown without password..."
+echo "Allow shutdown and systemctl without password..."
 sudo cp $DIR/hello_sudoers /etc/sudoers.d/
 
 echo "Setting up startup scripts..."

--- a/factory/22.04/stretch_initial_setup.sh
+++ b/factory/22.04/stretch_initial_setup.sh
@@ -126,7 +126,7 @@ echo "Setting up UDEV rules..."
 sudo cp /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules /etc/udev/rules.d
 sudo udevadm control --reload
 
-echo "Allow shutdown and systemctl without password..."
+echo "Allow commands without password..."
 sudo cp $DIR/hello_sudoers /etc/sudoers.d/
 
 echo "Setting up startup scripts..."

--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -157,7 +157,7 @@ echo "Install PyPCL and PyKDL"
 install python3-pcl python3-pykdl screen
 echo "Install PM2"
 sudo npm install -g pm2 &>> $REDIRECT_LOGFILE
-echo "Setup Sunshine systemd unit"
+echo "Setup Web Teleop systemd unit"
 mkdir -p ~/.config/systemd/user/
 cp ./web-teleop.service ~/.config/systemd/user/web-teleop.service
 echo ""

--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -157,6 +157,9 @@ echo "Install PyPCL and PyKDL"
 install python3-pcl python3-pykdl screen
 echo "Install PM2"
 sudo npm install -g pm2 &>> $REDIRECT_LOGFILE
+echo "Setup Sunshine systemd unit"
+mkdir -p ~/.config/systemd/user/
+cp ./web-teleop.service ~/.config/systemd/user/web-teleop.service
 echo ""
 
 echo "###########################################"

--- a/factory/22.04/web-teleop.service
+++ b/factory/22.04/web-teleop.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Web interface for Stretch robots.
+
+[Service]
+ExecStart=/home/hello-robot/ament_ws/src/stretch_web_teleop/launch_interface.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=graphical-session.target

--- a/factory/22.04/web-teleop.service
+++ b/factory/22.04/web-teleop.service
@@ -2,7 +2,7 @@
 Description=Web interface for Stretch robots.
 
 [Service]
-ExecStart=/home/hello-robot/ament_ws/src/stretch_web_teleop/launch_interface.sh
+ExecStart=/home/hello-robot/ament_ws/src/stretch_web_teleop/launch_interface.sh -f
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
This PR enables [Web Teleop](https://github.com/hello-robot/stretch_web_teleop/) to launch on boot. It sets up a systemd unit file to call the launch script for the interface. It changes `hello_sudoers` to ensure the launch script can use sudo without the interactive password prompt. It also installs `wifi-connect`, a software that enables Stretch to host a temporary hotspot for users to connect to and provide their home network credentials, because Web Teleop requires a wifi connection to operate.

## How to test

1. Clone this branch
```
cd ~ && git clone https://github.com/hello-robot/stretch_install -b feature/on_boot_web_teleop
```
1. Edit line 33 in `factory/22.04/stretch_ros2_humble.repos` to replace "master" with "tmp/scripts_login_signaling_voice_more"
1. Run a Stretch Install update:
```
cd ~/stretch_install && stretch_new_robot_install.sh -u
```
1. Change the hello_sudoers file:
```
sudo cp factory/22.04/hello_sudoers /etc/sudoers.d/hello_sudoers
```
1. Put `.env` in the root of your web teleop repo
1. Enable Web Teleop to start on boot
```
systemctl enable --user web-teleop
```
1. Reboot your robot and go to https://web.hello-robot.com/ to see if it comes online