### PR TITLE
Build venv for Stretch FUNMAP

### DIFF
--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -46,6 +46,7 @@ if [[ -d $AMENT_WSDIR ]]; then
     prompt_yes_no
 fi
 
+source ~/.bashrc &>> $REDIRECT_LOGFILE
 . /etc/hello-robot/hello-robot.conf
 export HELLO_FLEET_ID HELLO_FLEET_ID
 export HELLO_FLEET_PATH=${HOME}/stretch_user

--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -46,7 +46,7 @@ if [[ -d $AMENT_WSDIR ]]; then
     prompt_yes_no
 fi
 
-source ~/.bashrc &>> $REDIRECT_LOGFILE
+export PATH=${PATH}:~/.local/bin
 . /etc/hello-robot/hello-robot.conf
 export HELLO_FLEET_ID HELLO_FLEET_ID
 export HELLO_FLEET_PATH=${HOME}/stretch_user

--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -67,6 +67,8 @@ echo "Install APT HTTPS"
 install apt-transport-https
 echo "Install Network Security Services libraries"
 install libnss3-tools
+echo "Install uv"
+curl -LsSf https://astral.sh/uv/install.sh | sh &>> $REDIRECT_LOGFILE
 echo ""
 
 # https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html

--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -142,7 +142,7 @@ echo "INSTALLATION OF WEB INTERFACE"
 echo "###########################################"
 echo "Register the nodesource APT server's public key"
 function register_nodesource_apt_server {
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg
 }
 register_nodesource_apt_server &>> $REDIRECT_LOGFILE
 echo "Add the nodesource APT server to the list of APT respositories"

--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -49,8 +49,6 @@ install portaudio19-dev
 echo "Install lm-sensors & nvme-cli"
 install lm-sensors
 install nvme-cli
-echo "Install Cython for FUNMAP"
-install cython3
 echo "Install cheese for camera testing"
 install cheese
 echo "Install SSH Server"


### PR DESCRIPTION
This PR uses the [uv](https://docs.astral.sh/uv/) package manager to build a Python virtual environment for the Stretch FUNMAP package.

[Joshua's post](https://discourse.ros.org/t/status-of-colcon-building-standards-based-python-packages/40578/5) on ROS Discourse was very helpful in getting this working.

## Testing

Run a fresh [robot install](https://docs.hello-robot.com/0.3/installation/robot_install/), or:

1. Install [uv](https://docs.astral.sh/uv/)
2. Install `feature/venv_modifier_cli` branch from Stretch Factory
    ```
    git clone https://github.com/hello-robot/stretch_factory.git -b feature/venv_modifier_cli
    cd python
    pip3 install -e .
    ```
4. Check out this branch
    ```
    git clone https://github.com/hello-robot/stretch_install.git -b feature/uv_funmap
    ```
5. In the `./factory/22.04/stretch_ros2_humble.repos` file, change the Stretch ROS2 branch from "humble" to "feature/uv_funmap" on line 13
6. Create a ros workspace
    ```
    ./stretch_update_ros_workspace.sh
    ```

It should build successfully.