### PR TITLE
Fix setup new robot script and its corresponding dependency scripts

### DIFF
--- a/factory/18.04/stretch_create_catkin_workspace.sh
+++ b/factory/18.04/stretch_create_catkin_workspace.sh
@@ -66,7 +66,7 @@ echo "Update ~/.bashrc dotfile to source workspace..."
 echo "source $CATKIN_WSDIR/devel/setup.bash" >> ~/.bashrc
 echo "Updating meshes in stretch_ros to this robot's batch..."
 . /etc/hello-robot/hello-robot.conf
-export HELLO_FLEET_ID HELLO_FLEET_ID
+export HELLO_FLEET_ID=$HELLO_FLEET_ID
 export HELLO_FLEET_PATH=${HOME}/stretch_user
 $CATKIN_WSDIR/src/stretch_ros/stretch_description/meshes/update_meshes.py &>> $REDIRECT_LOGFILE
 echo "Setup uncalibrated robot URDF..."

--- a/factory/18.04/stretch_initial_setup.sh
+++ b/factory/18.04/stretch_initial_setup.sh
@@ -77,6 +77,7 @@ if [ $do_factory_install = 'false' ]; then
         exit 1
     fi
 fi
+chmod a-r $HOME/$HELLO_FLEET_ID
 
 echo "Waiting to get online..."
 while ! timeout 0.2 ping -c 1 -n google.com &> /dev/null

--- a/factory/18.04/stretch_initial_setup.sh
+++ b/factory/18.04/stretch_initial_setup.sh
@@ -77,7 +77,7 @@ if [ $do_factory_install = 'false' ]; then
         exit 1
     fi
 fi
-chmod a-r $HOME/$HELLO_FLEET_ID
+chmod -R a+r $HOME/$HELLO_FLEET_ID
 
 echo "Waiting to get online..."
 while ! timeout 0.2 ping -c 1 -n google.com &> /dev/null
@@ -124,11 +124,7 @@ else
 fi
 
 echo "Setting up UDEV rules..."
-for rule in /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules; do
-    if [ -f "$rule" ]; then
-        sudo cp "$rule" /etc/udev/rules.d/
-    fi
-done
+sudo cp /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules /etc/udev/rules.d
 sudo udevadm control --reload
 
 echo "Allow shutdown without password..."

--- a/factory/18.04/stretch_initial_setup.sh
+++ b/factory/18.04/stretch_initial_setup.sh
@@ -123,7 +123,11 @@ else
 fi
 
 echo "Setting up UDEV rules..."
-sudo cp /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules /etc/udev/rules.d
+for rule in /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules; do
+    if [ -f "$rule" ]; then
+        sudo cp "$rule" /etc/udev/rules.d/
+    fi
+done
 sudo udevadm control --reload
 
 echo "Allow shutdown without password..."

--- a/factory/20.04/stretch_create_catkin_workspace.sh
+++ b/factory/20.04/stretch_create_catkin_workspace.sh
@@ -67,7 +67,7 @@ echo "Update ~/.bashrc dotfile to source workspace..."
 echo "source $CATKIN_WSDIR/devel/setup.bash" >> ~/.bashrc
 echo "Updating meshes in stretch_ros to this robot's batch..."
 . /etc/hello-robot/hello-robot.conf
-export HELLO_FLEET_ID HELLO_FLEET_ID
+export HELLO_FLEET_ID=$HELLO_FLEET_ID
 export HELLO_FLEET_PATH=${HOME}/stretch_user
 $CATKIN_WSDIR/src/stretch_ros/stretch_description/batch/update_description.py &>> $REDIRECT_LOGFILE
 echo "Setup uncalibrated robot URDF..."

--- a/factory/20.04/stretch_initial_setup.sh
+++ b/factory/20.04/stretch_initial_setup.sh
@@ -76,6 +76,7 @@ if [ $do_factory_install = 'false' ]; then
         exit 1
     fi
 fi
+chmod a-r $HOME/$HELLO_FLEET_ID
 
 echo "Waiting to get online..."
 while ! timeout 0.2 ping -c 1 -n google.com &> /dev/null

--- a/factory/20.04/stretch_initial_setup.sh
+++ b/factory/20.04/stretch_initial_setup.sh
@@ -76,7 +76,7 @@ if [ $do_factory_install = 'false' ]; then
         exit 1
     fi
 fi
-chmod a-r $HOME/$HELLO_FLEET_ID
+chmod -R a+r $HOME/$HELLO_FLEET_ID
 
 echo "Waiting to get online..."
 while ! timeout 0.2 ping -c 1 -n google.com &> /dev/null
@@ -123,11 +123,7 @@ else
 fi
 
 echo "Setting up UDEV rules..."
-for rule in /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules; do
-    if [ -f "$rule" ]; then
-        sudo cp "$rule" /etc/udev/rules.d/
-    fi
-done
+sudo cp /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules /etc/udev/rules.d
 sudo udevadm control --reload
 
 echo "Allow shutdown without password..."

--- a/factory/20.04/stretch_initial_setup.sh
+++ b/factory/20.04/stretch_initial_setup.sh
@@ -122,7 +122,11 @@ else
 fi
 
 echo "Setting up UDEV rules..."
-sudo cp /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules /etc/udev/rules.d
+for rule in /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules; do
+    if [ -f "$rule" ]; then
+        sudo cp "$rule" /etc/udev/rules.d/
+    fi
+done
 sudo udevadm control --reload
 
 echo "Allow shutdown without password..."

--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -110,7 +110,7 @@ echo "Update ~/.bashrc dotfile to source workspace..."
 echo "source $AMENT_WSDIR/install/setup.bash" >> ~/.bashrc
 echo "source /usr/share/colcon_cd/function/colcon_cd.sh" >> ~/.bashrc
 echo "Updating meshes and xacros to ROS from stretch_urdf package."
-/home/$USER/.local/bin/stretch_urdf_ros_update.py -y -v >> $REDIRECT_LOGFILE || echo "Failed to update meshes and xacros to ROS from stretch_urdf package. Check if you have to migrate the RE1 params. Run '/home/hello-robot/.local/bin/RE1_migrate_params.py --path /home/hello-robot/stretch_user/$HELLO_FLEET_ID'" >> $REDIRECT_LOGFILE
+/home/$USER/.local/bin/stretch_urdf_ros_update.py -y -v >> $REDIRECT_LOGFILE
 echo "Setup uncalibrated robot URDF..."
 ros2 run stretch_calibration update_uncalibrated_urdf >> $REDIRECT_LOGFILE
 echo "Setup calibrated robot URDF..."

--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -22,42 +22,6 @@ echo "###########################################"
 echo "CREATING HUMBLE AMENT WORKSPACE at $AMENT_WSDIR"
 echo "###########################################"
 
-export PATH=${PATH}:~/.local/bin
-. /etc/hello-robot/hello-robot.conf
-export HELLO_FLEET_ID=$HELLO_FLEET_ID
-export HELLO_FLEET_PATH=${HOME}/stretch_user
-
-echo "Ensuring correct version of params present..."
-params_dir_path=$HELLO_FLEET_PATH/$HELLO_FLEET_ID
-echo "Checking params directory path: $params_dir_path"
-
-# Define file paths based on the provided directory
-user_params="$params_dir_path/stretch_re1_user_params.yaml"
-factory_params="$params_dir_path/stretch_re1_factory_params.yaml"
-new_config_params="$params_dir_path/stretch_configuration_params.yaml"
-new_user_params="$params_dir_path/stretch_user_params.yaml"
-
-# Check if the new files do not exist
-if [[ ! -f $new_config_params && ! -f $new_user_params ]]; then
-    # Check if the original RE1 files exist
-    if [[ -f $user_params && -f $factory_params ]]; then
-        echo "Old RE1 params are present. Starting the migration script..."
-        /home/$USER/.local/bin/RE1_migrate_params.py --path $dir_path >> $REDIRECT_LOGFILE
-        # Check if the script ran successfully
-        if [ $? -eq 0 ]; then
-            echo "Migration script ran successfully."
-        else
-            echo "Migration script failed. Exiting the script."
-            exit 1
-        fi
-    else
-        echo "Original RE1 parameter files are not found in the directory. Exiting the script."
-        exit 1
-    fi
-else
-    echo "Required parameter files are present in the directory. Skipping migration."
-fi
-
 echo "Ensuring correct version of ROS is sourced..."
 if [[ $ROS_DISTRO && ! $ROS_DISTRO = "humble" ]]; then
     echo "Cannot create workspace while a conflicting ROS version is sourced. Exiting."
@@ -82,6 +46,10 @@ if [[ -d $AMENT_WSDIR ]]; then
     prompt_yes_no
 fi
 
+export PATH=${PATH}:~/.local/bin
+. /etc/hello-robot/hello-robot.conf
+export HELLO_FLEET_ID=$HELLO_FLEET_ID
+export HELLO_FLEET_PATH=${HOME}/stretch_user
 echo "Updating rosdep indices..."
 rosdep update --include-eol-distros &>> $REDIRECT_LOGFILE
 echo "Deleting $AMENT_WSDIR if it already exists..."

--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -111,7 +111,7 @@ echo "source /usr/share/colcon_cd/function/colcon_cd.sh" >> ~/.bashrc
 # TODO: Use --no_prompt args to pass default True value to the click.confirm() function.
 # /home/hello-robot/.local/bin/RE1_migrate_params.py --path /home/hello-robot/stretch_user/$HELLO_FLEET_ID
 echo "Updating meshes and xacros to ROS from stretch_urdf package."
-/home/$USER/.local/bin/stretch_urdf_ros_update.py -y -v >> $REDIRECT_LOGFILE
+/home/$USER/.local/bin/stretch_urdf_ros_update.py -y -v >> $REDIRECT_LOGFILE || echo "Failed to update meshes and xacros to ROS from stretch_urdf package. Check if you have to migrate the RE1 params. Run '/home/hello-robot/.local/bin/RE1_migrate_params.py --path /home/hello-robot/stretch_user/$HELLO_FLEET_ID'" >> $REDIRECT_LOGFILE
 echo "Setup uncalibrated robot URDF..."
 ros2 run stretch_calibration update_uncalibrated_urdf >> $REDIRECT_LOGFILE
 echo "Setup calibrated robot URDF..."

--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -48,7 +48,7 @@ fi
 
 export PATH=${PATH}:~/.local/bin
 . /etc/hello-robot/hello-robot.conf
-export HELLO_FLEET_ID HELLO_FLEET_ID
+export HELLO_FLEET_ID=$HELLO_FLEET_ID
 export HELLO_FLEET_PATH=${HOME}/stretch_user
 echo "Updating rosdep indices..."
 rosdep update --include-eol-distros &>> $REDIRECT_LOGFILE
@@ -107,6 +107,9 @@ echo net.ipv4.ip_unprivileged_port_start=80 | sudo tee --append /etc/sysctl.d/99
 echo "Update ~/.bashrc dotfile to source workspace..."
 echo "source $AMENT_WSDIR/install/setup.bash" >> ~/.bashrc
 echo "source /usr/share/colcon_cd/function/colcon_cd.sh" >> ~/.bashrc
+# TODO: Insert Migration of RE1 params (if required)
+# TODO: Use --no_prompt args to pass default True value to the click.confirm() function.
+# /home/hello-robot/.local/bin/RE1_migrate_params.py --path /home/hello-robot/stretch_user/$HELLO_FLEET_ID
 echo "Updating meshes and xacros to ROS from stretch_urdf package."
 /home/$USER/.local/bin/stretch_urdf_ros_update.py -y -v >> $REDIRECT_LOGFILE
 echo "Setup uncalibrated robot URDF..."

--- a/factory/22.04/stretch_create_ament_workspace.sh
+++ b/factory/22.04/stretch_create_ament_workspace.sh
@@ -56,6 +56,7 @@ if [[ ! -f $new_config_params && ! -f $new_user_params ]]; then
     fi
 else
     echo "Required parameter files are present in the directory. Skipping migration."
+fi
 
 echo "Ensuring correct version of ROS is sourced..."
 if [[ $ROS_DISTRO && ! $ROS_DISTRO = "humble" ]]; then

--- a/factory/22.04/stretch_initial_setup.sh
+++ b/factory/22.04/stretch_initial_setup.sh
@@ -77,6 +77,7 @@ if [ $do_factory_install = 'false' ]; then
         exit 1
     fi
 fi
+chmod a-r $HOME/$HELLO_FLEET_ID
 
 echo "Waiting to get online..."
 while ! timeout 0.2 ping -c 1 -n google.com &> /dev/null

--- a/factory/22.04/stretch_initial_setup.sh
+++ b/factory/22.04/stretch_initial_setup.sh
@@ -77,7 +77,7 @@ if [ $do_factory_install = 'false' ]; then
         exit 1
     fi
 fi
-chmod a-r $HOME/$HELLO_FLEET_ID
+chmod -R a+r $HOME/$HELLO_FLEET_ID
 
 echo "Waiting to get online..."
 while ! timeout 0.2 ping -c 1 -n google.com &> /dev/null
@@ -124,11 +124,7 @@ else
 fi
 
 echo "Setting up UDEV rules..."
-for rule in /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules; do
-    if [ -f "$rule" ]; then
-        sudo cp "$rule" /etc/udev/rules.d/
-    fi
-done
+sudo cp /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules /etc/udev/rules.d
 sudo udevadm control --reload
 
 echo "Allow shutdown without password..."

--- a/factory/22.04/stretch_initial_setup.sh
+++ b/factory/22.04/stretch_initial_setup.sh
@@ -123,7 +123,11 @@ else
 fi
 
 echo "Setting up UDEV rules..."
-sudo cp /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules /etc/udev/rules.d
+for rule in /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules; do
+    if [ -f "$rule" ]; then
+        sudo cp "$rule" /etc/udev/rules.d/
+    fi
+done
 sudo udevadm control --reload
 
 echo "Allow shutdown without password..."

--- a/stretch_new_user_install.sh
+++ b/stretch_new_user_install.sh
@@ -72,6 +72,7 @@ if [ "$UPDATING" = true ]; then
     echo "~/stretch_user/$HELLO_FLEET_ID data present: not updating"
 else
     sudo cp -rf /etc/hello-robot/$HELLO_FLEET_ID $HOME/stretch_user
+    sudo chown $USER:$USER $HOME/stretch_user/$HELLO_FLEET_ID
     chmod a-w $HOME/stretch_user/$HELLO_FLEET_ID/udev/*.rules
 fi
 chmod -R a-x,o-w,+X ~/stretch_user
@@ -161,8 +162,17 @@ new_user_params="$params_dir_path/stretch_user_params.yaml"
 if [[ ! -f $new_config_params && ! -f $new_user_params ]]; then
     # Check if the original RE1 files exist
     if [[ -f $user_params && -f $factory_params ]]; then
-        echo "Old RE1 params are present. Starting the migration scripts..."
+        echo "Old RE1 params are present. Starting param migration..."
         /home/$USER/.local/bin/RE1_migrate_params.py --path $dir_path
+        # Check if the script ran successfully
+        if [ $? -eq 0 ]; then
+            echo "Migration script ran successfully."
+        else
+            echo "Migration script failed. Exiting the script."
+            exit 1
+        fi
+
+        echo "Migrating contact params..."
         /home/$USER/.local/bin/RE1_migrate_contacts.py --path $dir_path
         # Check if the script ran successfully
         if [ $? -eq 0 ]; then

--- a/stretch_new_user_install.sh
+++ b/stretch_new_user_install.sh
@@ -72,7 +72,12 @@ if [ "$UPDATING" = true ]; then
     echo "~/stretch_user/$HELLO_FLEET_ID data present: not updating"
 else
     sudo cp -rf /etc/hello-robot/$HELLO_FLEET_ID $HOME/stretch_user
-    sudo chmod a-w $HOME/stretch_user/$HELLO_FLEET_ID/udev/*.rules
+    sudo chown -R $USER:$USER /home/hello-robot/stretch_user/$HELLO_FLEET_ID
+    for rule in /etc/hello-robot/$HELLO_FLEET_ID/udev/*.rules; do
+        if [ -f "$rule" ]; then
+            sudo chmod a-w $rule
+        fi
+    done
     #chmod a-w $HOME/stretch_user/$HELLO_FLEET_ID/calibration_steppers/*.yaml
 fi
 

--- a/stretch_new_user_install.sh
+++ b/stretch_new_user_install.sh
@@ -71,8 +71,8 @@ echo "Setting up user copy of robot factory data (if not already there)..."
 if [ "$UPDATING" = true ]; then
     echo "~/stretch_user/$HELLO_FLEET_ID data present: not updating"
 else
-    cp -rf /etc/hello-robot/$HELLO_FLEET_ID $HOME/stretch_user
-    chmod a-w $HOME/stretch_user/$HELLO_FLEET_ID/udev/*.rules
+    sudo cp -rf /etc/hello-robot/$HELLO_FLEET_ID $HOME/stretch_user
+    sudo chmod a-w $HOME/stretch_user/$HELLO_FLEET_ID/udev/*.rules
     #chmod a-w $HOME/stretch_user/$HELLO_FLEET_ID/calibration_steppers/*.yaml
 fi
 


### PR DESCRIPTION
Fixed some errors from #88.

## Description

This PR addresses several issues and enhancements in the Stretch Robot setup scripts. The changes include:

1. **Setting up UDEV rules**:
    - fixed read permissions before copying

2. **Migration of RE1**:
    - Added feature to check if the latest param present if not start the migration script.

3. **User copy of robot factory data**:
    - Ensured that the user copy of robot factory data is set up correctly.
    - Added commands to change ownership and permissions of the copied files.

## Testing

- Verified that the UDEV rules are correctly copied and reloaded.
- Checked that the user copy of robot factory data is set up with correct permissions.
- Migration script kicks in if old RE1 param are present.

---

Please review the changes and let me know if any further modifications are needed.