### PR TITLE
Add cmd line arguments and env variable to take in hello fleet id to skip user input

### DIFF
--- a/factory/18.04/stretch_initial_setup.sh
+++ b/factory/18.04/stretch_initial_setup.sh
@@ -8,14 +8,15 @@ if $do_factory_install; then
 fi
 echo "WARNING: Run this installation for fresh Ubuntu installs only."
 
-# Check for environment variables or prompt for HELLO_FLEET_ID
-if [[ -n "$HELLO_FLEET_ID" ]]; then
-    echo "Using HELLO_FLEET_ID from environment: $HELLO_FLEET_ID"
-elif [[ -n "$HELLO_MODEL" && -n "$HELLO_FLEET_NUMBER" ]]; then
-    HELLO_FLEET_ID="${HELLO_MODEL}-${HELLO_FLEET_NUMBER}"
+# Process automation variables from parent script
+if [[ -n "$SETUP_FLEET_ID" ]]; then
+    echo "Using SETUP_FLEET_ID from environment: $SETUP_FLEET_ID"
+    HELLO_FLEET_ID="$SETUP_FLEET_ID"
+elif [[ -n "$SETUP_MODEL" && -n "$SETUP_FLEET_NUMBER" ]]; then
+    HELLO_FLEET_ID="${SETUP_MODEL}-${SETUP_FLEET_NUMBER}"
     echo "Using HELLO_FLEET_ID constructed from environment variables: $HELLO_FLEET_ID"
 else
-    # Original interactive prompt if no environment variables provided
+    # Original interactive prompt if no automation variables provided
     echo "Checking ~/.bashrc doesn't already define HELLO_FLEET_ID..."
     if [[ $HELLO_FLEET_ID ]]; then
         echo "Expecting var HELLO_FLEET_ID to be undefined. Check end of ~/.bashrc file, delete all lines in 'STRETCH BASHRC SETUP' section, and open a new terminal. Exiting."

--- a/factory/20.04/stretch_initial_setup.sh
+++ b/factory/20.04/stretch_initial_setup.sh
@@ -8,14 +8,15 @@ if $do_factory_install; then
 fi
 echo "WARNING: Run this installation for fresh Ubuntu installs only."
 
-# Check for environment variables or prompt for HELLO_FLEET_ID
-if [[ -n "$HELLO_FLEET_ID" ]]; then
-    echo "Using HELLO_FLEET_ID from environment: $HELLO_FLEET_ID"
-elif [[ -n "$HELLO_MODEL" && -n "$HELLO_FLEET_NUMBER" ]]; then
-    HELLO_FLEET_ID="${HELLO_MODEL}-${HELLO_FLEET_NUMBER}"
+# Process automation variables from parent script
+if [[ -n "$SETUP_FLEET_ID" ]]; then
+    echo "Using SETUP_FLEET_ID from environment: $SETUP_FLEET_ID"
+    HELLO_FLEET_ID="$SETUP_FLEET_ID"
+elif [[ -n "$SETUP_MODEL" && -n "$SETUP_FLEET_NUMBER" ]]; then
+    HELLO_FLEET_ID="${SETUP_MODEL}-${SETUP_FLEET_NUMBER}"
     echo "Using HELLO_FLEET_ID constructed from environment variables: $HELLO_FLEET_ID"
 else
-    # Original interactive prompt if no environment variables provided
+    # Original interactive prompt if no automation variables provided
     echo "Checking ~/.bashrc doesn't already define HELLO_FLEET_ID..."
     if [[ $HELLO_FLEET_ID ]]; then
         echo "Expecting var HELLO_FLEET_ID to be undefined. Check end of ~/.bashrc file, delete all lines in 'STRETCH BASHRC SETUP' section, and open a new terminal. Exiting."

--- a/factory/22.04/stretch_initial_setup.sh
+++ b/factory/22.04/stretch_initial_setup.sh
@@ -8,14 +8,15 @@ if $do_factory_install; then
 fi
 echo "WARNING: Run this installation for fresh Ubuntu installs only."
 
-# Check for environment variables or prompt for HELLO_FLEET_ID
-if [[ -n "$HELLO_FLEET_ID" ]]; then
-    echo "Using HELLO_FLEET_ID from environment: $HELLO_FLEET_ID"
-elif [[ -n "$HELLO_MODEL" && -n "$HELLO_FLEET_NUMBER" ]]; then
-    HELLO_FLEET_ID="${HELLO_MODEL}-${HELLO_FLEET_NUMBER}"
+# Process automation variables from parent script
+if [[ -n "$SETUP_FLEET_ID" ]]; then
+    echo "Using SETUP_FLEET_ID from environment: $SETUP_FLEET_ID"
+    HELLO_FLEET_ID="$SETUP_FLEET_ID"
+elif [[ -n "$SETUP_MODEL" && -n "$SETUP_FLEET_NUMBER" ]]; then
+    HELLO_FLEET_ID="${SETUP_MODEL}-${SETUP_FLEET_NUMBER}"
     echo "Using HELLO_FLEET_ID constructed from environment variables: $HELLO_FLEET_ID"
 else
-    # Original interactive prompt if no environment variables provided
+    # Original interactive prompt if no automation variables provided
     echo "Checking ~/.bashrc doesn't already define HELLO_FLEET_ID..."
     if [[ $HELLO_FLEET_ID ]]; then
         echo "Expecting var HELLO_FLEET_ID to be undefined. Check end of ~/.bashrc file, delete all lines in 'STRETCH BASHRC SETUP' section, and open a new terminal. Exiting."


### PR DESCRIPTION

Addressed issue #90 

# Add command-line and environment variable support for robot fleet ID

## Summary
This PR enhances the robot installation process by adding support for setting the robot's fleet ID via command-line arguments and environment variables, eliminating the need for interactive input during installation while avoiding conflicts with existing environment checks.

## Changes
- Added new command-line arguments to `stretch_new_robot_install.sh`:
  - `-m MODEL`: Set the model type (stretch-re1, stretch-re2, stretch-se3)
  - `-i ID`: Set the 4-digit fleet ID
  - `-H ID`: Set the complete fleet ID directly (e.g., stretch-re2-1234)
  - `-h`: Display help information with examples
- Introduced `SETUP_*` environment variables that avoid conflicts with existing `HELLO_FLEET_ID` checks
- Added robust fleet ID validation in the parent script to catch errors early
- Modified all OS-specific `stretch_initial_setup.sh` scripts (18.04, 20.04, 22.04) to work with the new variables
- Maintained backward compatibility with the original interactive behavior as a fallback

## Benefits
- Enables automated installations without requiring user input
- Uses `SETUP_*` variables to avoid conflicts with existing checks
- Validates fleet ID format upfront to prevent later installation failures
- Provides multiple ways to specify the fleet ID
- Added help text that explains all options with examples

## Example Usage
```bash
# Set fleet ID with separate options
./stretch_new_robot_install.sh -m stretch-re2 -i 1234

# Set complete fleet ID
./stretch_new_robot_install.sh -H stretch-re2-1234

# Use environment variables
SETUP_FLEET_ID=stretch-re2-1234 ./stretch_new_robot_install.sh

# Use combined environment variables
SETUP_MODEL=stretch-re2 SETUP_FLEET_NUMBER=1234 ./stretch_new_robot_install.sh

# View help
./stretch_new_robot_install.sh -h
```

## Testing
Tested on Ubuntu 22.04 with various fleet ID input methods to ensure proper validation and passing of parameters between scripts.
