### PR TITLE
Fix i386 warning

### DIFF
--- a/factory/22.04/stretch_install_system.sh
+++ b/factory/22.04/stretch_install_system.sh
@@ -146,7 +146,7 @@ register_nodesource_apt_server &>> $REDIRECT_LOGFILE
 echo "Add the nodesource APT server to the list of APT respositories"
 function add_nodesource_apt_server {
     NODE_MAJOR=21
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg, arch=amd64] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 }
 add_nodesource_apt_server &>> $REDIRECT_LOGFILE
 echo "Apt update"


### PR DESCRIPTION
Warning appears when doing `sudo apt update`:
```
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https ://deb.nodesource.com/node_21.x nodistro InRelease' doesn't support architecture 'i386'
```

Testing
----------

On an existing system, simply edit `/etc/apt/sources.list.d/nodesource.list` to add ", arch=amd64" like so:
```
deb [signed-by=/etc/apt/keyrings/nodesource.gpg, arch=amd64] https://deb.nodesource.com/node_21.x nodistro main
```
After saving, try `sudo apt update`