### PR TITLE
Fix env variable for stretch_user params path

### DIFF
--- a/stretch_new_user_install.sh
+++ b/stretch_new_user_install.sh
@@ -163,7 +163,7 @@ if [[ ! -f $new_config_params && ! -f $new_user_params ]]; then
     # Check if the original RE1 files exist
     if [[ -f $user_params && -f $factory_params ]]; then
         echo "Old RE1 params are present. Starting param migration..."
-        /home/$USER/.local/bin/RE1_migrate_params.py --path $dir_path
+        /home/$USER/.local/bin/RE1_migrate_params.py --path $params_dir_path
         # Check if the script ran successfully
         if [ $? -eq 0 ]; then
             echo "Migration script ran successfully."
@@ -173,7 +173,7 @@ if [[ ! -f $new_config_params && ! -f $new_user_params ]]; then
         fi
 
         echo "Migrating contact params..."
-        /home/$USER/.local/bin/RE1_migrate_contacts.py --path $dir_path
+        /home/$USER/.local/bin/RE1_migrate_contacts.py --path $params_dir_path
         # Check if the script ran successfully
         if [ $? -eq 0 ]; then
             echo "Migration script ran successfully."


### PR DESCRIPTION
Bug found while following the new robot install guide [[link](https://github.com/hello-robot/stretch_install/blob/master/docs/robot_install.md)] on a Stretch RE1.

Inside of `stretch_new_robot_install.sh`, I encountered the following issue with `stretch_new_user_install.sh`:

```bash
###########################################
INSTALLATION OF USER LEVEL PIP3 PACKAGES
###########################################
Upgrade pip3
Clear pip cache
Install Stretch Body
Install Stretch Body Tools
Install Stretch Factory
Install Stretch Tool Share
Install Stretch Diagnostics
Install Stretch URDF
Upgrade prompt_toolkit
Remove setuptools-scm

Ensuring correct version of params present...
Checking params directory path: /home/hello-robot/stretch_user/stretch-re1-1058
Old RE1 params are present. Starting param migration...
usage: RE1_migrate_params.py [-h] [--no_prompt] [--diff] [--path PATH]
RE1_migrate_params.py: error: argument --path: expected one argument

#############################################
FAILURE. INSTALLATION DID NOT COMPLETE.
Look at the troubleshooting guide for solutions to common issues: https://docs.hello-robot.com/0.3/installation/robot_install/#troubleshooting
or contact Hello Robot support and include /home/hello-robot/stretch_user/log/stretch_install_202511171115/stretch_robot_install_logs.zip
#############################################
```

Echoing `$dir_path` inside the script returned nothing; changing `$dir_path` to `$params_dir_path` seemed to fix the error. If this is something specific to my system, feel free to close this PR.