### PR TITLE
Avoid chmod of missing ~/$HOME/$HELLO_FLEET_ID during factory installs

### DIFF
--- a/factory/18.04/stretch_initial_setup.sh
+++ b/factory/18.04/stretch_initial_setup.sh
@@ -81,8 +81,8 @@ if [ $do_factory_install = 'false' ]; then
         echo "Expecting robot calibration $HELLO_FLEET_ID to be present in the the home folder. Exiting."
         exit 1
     fi
+    chmod -R a+r $HOME/$HELLO_FLEET_ID
 fi
-chmod -R a+r $HOME/$HELLO_FLEET_ID
 
 echo "Waiting to get online..."
 while ! timeout 0.2 ping -c 1 -n google.com &> /dev/null

--- a/factory/20.04/stretch_initial_setup.sh
+++ b/factory/20.04/stretch_initial_setup.sh
@@ -80,8 +80,8 @@ if [ $do_factory_install = 'false' ]; then
         echo "Expecting robot calibration $HELLO_FLEET_ID to be present in the the home folder. Exiting."
         exit 1
     fi
+    chmod -R a+r $HOME/$HELLO_FLEET_ID
 fi
-chmod -R a+r $HOME/$HELLO_FLEET_ID
 
 echo "Waiting to get online..."
 while ! timeout 0.2 ping -c 1 -n google.com &> /dev/null

--- a/factory/22.04/stretch_initial_setup.sh
+++ b/factory/22.04/stretch_initial_setup.sh
@@ -80,8 +80,8 @@ if [ $do_factory_install = 'false' ]; then
         echo "Expecting robot calibration $HELLO_FLEET_ID to be present in the the home folder. Exiting."
         exit 1
     fi
+    chmod -R a+r $HOME/$HELLO_FLEET_ID
 fi
-chmod -R a+r $HOME/$HELLO_FLEET_ID
 
 echo "Waiting to get online..."
 while ! timeout 0.2 ping -c 1 -n google.com &> /dev/null


### PR DESCRIPTION
Factory installs (-f) skip the local calibration directory check but still attempted to `chmod $HOME/$HELLO_FLEET_ID`, causing installs to fail when the directory is not present.


```
hello-robot@stretch-re2-2021:~/stretch_install$ ./stretch_new_robot_install.sh -f
[sudo] password for hello-robot:
#############################################
STARTING NEW ROBOT INSTALL
#############################################
WARNING: Running a FACTORY install. This is only meant to be run at Hello Robot HQ.
WARNING: Run this installation for fresh Ubuntu installs only.
Checking ~/.bashrc doesn't already define HELLO_FLEET_ID...
1) stretch-re1
2) stretch-re2
3) stretch-se3
Select model type: 2
Selected model: stretch-re2
Enter fleet id xxxx for stretch-re2-xxxx> 2021
HELLO_FLEET_ID will be stretch-re2-2021.
Plug in charger & attach clip-clamp before proceeding.
Ready to proceed with installation (y/n)? y
Checking Stretch Install cloned to right place...
chmod: cannot access '/home/hello-robot/stretch-re2-2021': No such file or directory
```
This change moves the chmod into the non-factory path, where the directory is required, and avoids touching the home-folder calibration path during factory installs.