### PR TITLE
Improve Stretch install script on Ubuntu 20.04

### DIFF
--- a/factory/20.04/stretch_install_system.sh
+++ b/factory/20.04/stretch_install_system.sh
@@ -17,7 +17,7 @@ echo "###########################################"
 echo "Apt update & upgrade (this might take a while)"
 sudo apt-add-repository universe >> $REDIRECT_LOGFILE
 sudo apt-get --yes update >> $REDIRECT_LOGFILE
-sudo apt-get --yes upgrade &>> $REDIRECT_LOGFILE
+sudo DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade &>> $REDIRECT_LOGFILE
 echo "Install zip & unzip"
 install zip unzip
 echo "Install Curl"

--- a/factory/20.04/stretch_install_system.sh
+++ b/factory/20.04/stretch_install_system.sh
@@ -124,11 +124,16 @@ echo "Install dynamic reconfiguration"
 install ros-noetic-ddynamic-reconfigure ros-noetic-ddynamic-reconfigure-python
 echo "Register the librealsense APT server's public key"
 function register_librealsense_apt_server {
-    sudo apt-key adv --keyserver keys.gnupg.net --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key FB0B24895113F120
 }
 register_librealsense_apt_server &>> $REDIRECT_LOGFILE
+
 echo "Add the librealsense APT server to the list of APT repositories"
-sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo bionic main" -u &>> $REDIRECT_LOGFILE
+function add_librealsense_apt_server {
+    echo "deb https://librealsense.intel.com/Debian/apt-repo bionic main" | sudo tee /etc/apt/sources.list.d/librealsense.list
+}
+add_librealsense_apt_server &>> $REDIRECT_LOGFILE
 echo "Remove old records in case of upgrading"
 sudo rm -f /etc/apt/sources.list.d/realsense-public.list
 echo "Apt update"


### PR DESCRIPTION
- Makes `apt-get upgrade` fully non-interactive to prevent blocking prompts and preserve existing config files during automated installs

- Updates RealSense D435i installation (keys + repo setup) for improved reliability and consistency on Ubuntu 20.04 systems